### PR TITLE
Support PNGs

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function photo (id, callback) {
         server: info.server,
         secret: info.secret,
         osecret: info.originalsecret,
-        format: "jpg"
+        format: info.originalformat
       })
     });
   });

--- a/test.js
+++ b/test.js
@@ -50,3 +50,12 @@ test('urls', function (t) {
     t.deepEqual(craterlake.urls.original, "https:\/\/farm3.staticflickr.com\/2922\/14321741011_0ddc14584b_o.jpg");
   });
 });
+
+test('png format', function (t) {
+  photo('14605009770', function (error, twister) {
+    t.plan(3);
+    t.error(error);
+    t.equal(twister.id, '14605009770');
+    t.equal(twister.format, "png");
+  });
+});


### PR DESCRIPTION
This fix passes along the original format from the Flickr API request, instead of a hardcoded `jpg` string.
