### PR TITLE
owner username property source

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function photo (id, callback) {
       views: Number(info.views),
       owner: {
         id: info.owner.nsid,
-        username: info.owner.path_alias,
+        username: info.owner.username || info.owner.path_alias,
         name: info.owner.realname,
         url: "https://flickr.com/photos/" + info.owner.path_alias,
         icons: {


### PR DESCRIPTION
the `info.owner.username` property may be defined and is probably the highest priority source for the `photo.owner.username` destination. sometimes `info.owner.path_alias` is empty and then the username property is lost.